### PR TITLE
[16.0][IMP] stock_available_immediately_exclude_location:  Improves perf

### DIFF
--- a/stock_available_immediately_exclude_location/__manifest__.py
+++ b/stock_available_immediately_exclude_location/__manifest__.py
@@ -7,7 +7,7 @@
     "website": "https://github.com/OCA/stock-logistics-availability",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["stock_available_immediately"],
+    "depends": ["stock_available_immediately", "stock_available_location_get_domain"],
     "data": ["views/stock_location.xml"],
     "category": "Hidden",
     "installable": True,

--- a/stock_available_immediately_exclude_location/models/product_product.py
+++ b/stock_available_immediately_exclude_location/models/product_product.py
@@ -1,8 +1,9 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import api, fields, models
 from odoo.osv import expression
+from odoo.tools import ormcache_context
 
 
 class ProductProduct(models.Model):
@@ -15,56 +16,137 @@ class ProductProduct(models.Model):
         in excluded locations
         """
         res, stock_dict = super()._compute_available_quantities_dict()
-        exclude_location_ids = (
-            self._get_locations_excluded_from_immediately_usable_qty().ids
+        excluded_qty_dict = (
+            self._get_qty_available_in_locations_excluded_from_immadiatly_usable_qty()
         )
-
-        if exclude_location_ids:
-            excluded_qty_dict = self.with_context(
-                location=exclude_location_ids, compute_child=False
-            )._compute_quantities_dict(
-                self._context.get("lot_id"),
-                self._context.get("owner_id"),
-                self._context.get("package_id"),
-                self._context.get("from_date"),
-                self._context.get("to_date"),
-            )
-
-        for product_id in res:
-            if exclude_location_ids:
-                res[product_id]["immediately_usable_qty"] -= excluded_qty_dict[
-                    product_id
-                ]["qty_available"]
+        for product_id, qty in excluded_qty_dict.items():
+            res[product_id]["immediately_usable_qty"] -= qty
         return res, stock_dict
 
+    def _get_qty_available_in_locations_excluded_from_immadiatly_usable_qty(self):
+        """Return a dict of qty available by product
+        into excluded locations. If no location is excluded
+        retrurn an empty dict
+        """
+        exclude_location_ids = (
+            self._get_location_ids_excluded_from_immediately_usable_qty()
+        )
+        if not exclude_location_ids:
+            return {}
+
+        context = self.env.context
+        to_date = context.get("to_date")
+        to_date = fields.Datetime.to_datetime(to_date)
+        dates_in_the_past = False
+        if to_date and to_date < fields.Datetime.now():
+            dates_in_the_past = True
+
+        # we use strict=True to avoid time consuming query criteria on location
+        # to get children locations of the excluded locations. The method
+        # _get_location_ids_excluded_from_immediately_usable_qty has already
+        # resolved the children locations of the excluded locations.
+        products_with_excluded_loc = self.with_context(
+            location=exclude_location_ids, strict=True
+        )
+
+        if dates_in_the_past:
+            # we call the original _compute_quantities_dict since
+            # the qty_available will be computed from quants and
+            # moves
+            excluded_qty_dict = products_with_excluded_loc._compute_quantities_dict(
+                context.get("lot_id"),
+                context.get("owner_id"),
+                context.get("package_id"),
+                context.get("from_date"),
+                to_date,
+            )
+            return {p: q["qty_available"] for p, q in excluded_qty_dict.items()}
+        # we are not in the past, the qty available is the sum of quant's qties
+        # into the exluded locations. A simple read_group will do the job.
+        # By avoiding the call to _compute_quantities_dict, we avoid 2 useless
+        # queries to the database to retrieve the incoming and outgoing moves
+        # that are not needed here and therefore improve the performance.
+        (
+            domain_quant_loc,
+            _domain_move_in_loc,
+            _domain_move_out_loc,
+        ) = products_with_excluded_loc._get_domain_locations()
+        domain_quant = [("product_id", "in", self.ids)] + domain_quant_loc
+        quant = self.env["stock.quant"].with_context(active_test=False)
+        return {
+            item["product_id"][0]: item["quantity"]
+            for item in quant._read_group(
+                domain_quant,
+                ["product_id", "quantity"],
+                ["product_id"],
+                orderby="id",
+            )
+        }
+
+    @api.model
+    @ormcache_context(
+        "tuple(self.env.companies.ids)", keys=("tuple(location)", "tuple(warehouse)")
+    )
+    def _get_location_ids_excluded_from_immediately_usable_qty(self):
+        """
+        Return the ids of the locations that should be excluded from the
+        immediately_usable_qty. This method return the ids of leaf locations
+        that are excluded from the immediately_usable_qty and the children of
+        the view locations that are excluded from the immediately_usable_qty.
+        """
+        locations = self._get_locations_excluded_from_immediately_usable_qty()
+        view_locations = locations.filtered(lambda l: l.usage == "view")
+        # we must exclude the children of the view locations
+        locations |= self.env["stock.location"].search(
+            [
+                ("location_id", "child_of", view_locations.ids),
+                ("usage", "in", ["internal", "transit"]),
+            ]
+        )
+        return locations.ids
+
+    @api.model
     def _get_locations_excluded_from_immediately_usable_qty(self):
         return self.env["stock.location"].search(
             self._get_domain_location_excluded_from_immediately_usable_qty()
         )
 
+    @api.model
     def _get_domain_location_excluded_from_immediately_usable_qty(self):
         """
         Parses the context and returns a list of location_ids based on it that
         should be excluded from the immediately_usable_qty
         """
-        quant_domain = self.env["product.product"]._get_domain_locations()[0]
-        # Adapt the domain on quants (which normally contains only company_id and
-        # location_id) for stock.location and add the criteria on
-        # exclude_from_immediately_usable_qty to it.
-        # Be sure to exclude potential fields that couldn't belong to stock.location
-        # and replace such term by something True domain compatible
-        location_domain = []
-        location_fields = self.env["stock.location"].fields_get()
-        for element in quant_domain:
-            if expression.is_leaf(element) and element[0] not in location_fields:
-                # exclude the element from domain and replace by something True
-                location_domain.append((1, "=", 1))  # True and domain compatible
-            elif expression.is_leaf(element):
-                location_domain.append(
-                    (element[0].replace("location_id.", ""), element[1], element[2])
-                )
-            else:
-                location_domain.append(element)
+        location_domain = self.env[
+            "product.product"
+        ]._get_domain_location_for_locations()
         return expression.AND(
             [location_domain, [("exclude_from_immediately_usable_qty", "=", True)]]
+        )
+
+    def _get_domain_locations_new(self, location_ids):
+        # We override this method to add the possibility to work with a strict
+        # context parameter. This parameter is used to force the method to
+        # restrict the domain to the location_ids passed as parameter in place
+        # if considering all locations children of the location_ids.
+        # Prior to Odoo 16, this behavior was possible by setting the context
+        # parameter 'compute_child' to False. This parameter has been removed
+        # in Odoo 16 in commit https://github.com/odoo/odoo/commit/
+        # f054af31b098d8cb1ef64369e857a36c70918033 and reintroduced in Odoo >= 17
+        # in commit https://github.com/odoo/odoo/commit/
+        # add97b3c2dc1df70d22f87047cf012463f3e12c4 as 'strict' context parameter.
+        # The original design of this addon developped for Odoo 10 has always
+        # been to consider only the locations passed as parameter and not their
+        # children to avoid performance issues. This is why we reintroduce this
+        # behavior.
+        if not self.env.context.get("strict"):
+            return super()._get_domain_locations_new(location_ids)
+
+        location_ids = list(location_ids)
+        loc_domain = [("location_id", "in", location_ids)]
+        dest_loc_domain = [("location_dest_id", "in", location_ids)]
+        return (
+            loc_domain,
+            dest_loc_domain + ["!"] + loc_domain if loc_domain else dest_loc_domain,
+            loc_domain + ["!"] + dest_loc_domain if dest_loc_domain else loc_domain,
         )

--- a/stock_available_immediately_exclude_location/models/stock_location.py
+++ b/stock_available_immediately_exclude_location/models/stock_location.py
@@ -1,7 +1,7 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockLocation(models.Model):
@@ -14,3 +14,21 @@ class StockLocation(models.Model):
         index=True,
         help="This property is not inherited by children locations",
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        self._invalidate_location_ids_excluded_from_immediatley_usable_qty_cache()
+        return res
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("exclude_from_immediately_usable_qty"):
+            self._invalidate_location_ids_excluded_from_immediatley_usable_qty_cache()
+        return res
+
+    def _invalidate_location_ids_excluded_from_immediatley_usable_qty_cache(self):
+        product_model = self.env["product.product"]
+        product_model._get_location_ids_excluded_from_immediately_usable_qty.clear_cache(
+            product_model
+        )

--- a/stock_available_immediately_exclude_location/readme/CONTRIBUTORS.rst
+++ b/stock_available_immediately_exclude_location/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Author: Hughes Damry <hughes.damry@acsone.eu>
+* Laurent Mignon <laurent.mignon@acsone.eu>


### PR DESCRIPTION
* [x] depends on #11 

It improves the perfs of the module by:

* Caching the list of locations to exclude from the immediately available quantity computation.
* Avoiding to query the incoming and outgoing quantities for the locations to exclude when computing the available quantity into the locations to exclude.
* Replace specific code to compute the location domain from the stock quant domain by a call to a method provided by the stock_available_location_get_domain addon. This new method significantly improves the performances by avoiding the call to the 'fields_get' method on the model.
* Computing the available quantity for excluded locations on strict mode. IOW the available quantity is computed
on records that are linked directly to the location_id and not on records that are linked to a location child of the excluded locations. 

As result, on the workbench used when profiling the module, the time to compute the available quantity is reduced in the worst case from 244ms to 120ms (50% improvement) and on average from +/- 180ms to 74 ms (59% improvement).

Optimization in images....

### Initial state
![image](https://github.com/user-attachments/assets/b7bc00fc-e37d-40f9-82c3-11c302b34d3e)

### Using the new way to get the location domain from the quant domain
![image](https://github.com/user-attachments/assets/be9d0d84-17b2-405a-a323-7fc5d1091c2b)

### Caching the list of locations to exclude and removing 2 useless queries on stock.move
![image](https://github.com/user-attachments/assets/ea6edadc-6f8d-4593-80b3-816ae16a87d5)

### Using strict mode when computing available qties on excluded locations
![image](https://github.com/user-attachments/assets/b30d43f5-b926-4a98-be0d-c0c98f8a6c7f)

