### PR TITLE
[16.0][IMP] stock_available_immediately: Change the refresh() method to invalidate_model to avoid the warning log

### DIFF
--- a/stock_available_immediately/tests/test_stock_available_immediately.py
+++ b/stock_available_immediately/tests/test_stock_available_immediately.py
@@ -71,7 +71,7 @@ class TestStockLogisticsWarehouse(TransactionCase):
         def compare_product_usable_qty(product, value):
             # Refresh, because the function field is not recalculated between
             # transactions
-            product.refresh()
+            product.invalidate_model()
             self.assertEqual(product.immediately_usable_qty, value)
 
         compare_product_usable_qty(productA, 0)


### PR DESCRIPTION
Change the `refresh()` method to `invalidate_model` to avoid the warning log

`WARNING prod py.warnings: /opt/odoo/auto/addons/stock_available_immediately/tests/test_stock_available_immediately.py:74: DeprecationWarning: refresh() is deprecated method, use invalidate_cache() instead`

@Tecnativa