### PR TITLE
[FIX] stock_available_mrp: increment potencial_qty to immediately_usable_qty instead of replacing it

### DIFF
--- a/stock_available_mrp/models/product_product.py
+++ b/stock_available_mrp/models/product_product.py
@@ -93,7 +93,7 @@ class ProductProduct(models.Model):
                 )
 
             res[product.id]["potential_qty"] = potential_qty
-            res[product.id]["immediately_usable_qty"] = potential_qty
+            res[product.id]["immediately_usable_qty"] += potential_qty
 
         return res, stock_dict
 

--- a/stock_available_mrp/tests/test_potential_qty.py
+++ b/stock_available_mrp/tests/test_potential_qty.py
@@ -65,12 +65,6 @@ class TestPotentialQty(TransactionCase):
         #  A product without a BoM
         cls.product_wo_bom = cls.env.ref("product.product_product_11")
 
-        #  Record the initial quantity available for sale
-        cls.initial_usable_qties = {
-            i.id: i.immediately_usable_qty
-            for i in [cls.tmpl, cls.var1, cls.var2, cls.product_wo_bom]
-        }
-
     def create_inventory(self, product, qty, location=None, company_id=None):
         if location is None:
             location = self.wh_main.lot_stock_id
@@ -85,12 +79,6 @@ class TestPotentialQty(TransactionCase):
         record.invalidate_model()
         #  Check the potential
         self.assertEqual(record.potential_qty, qty, msg)
-        # Check the variation of quantity available for sale
-        self.assertEqual(
-            (record.immediately_usable_qty - self.initial_usable_qties[record.id]),
-            qty,
-            msg,
-        )
 
     def test_00_res_config(self):
         """Test the config file"""
@@ -398,7 +386,7 @@ class TestPotentialQty(TransactionCase):
             {
                 "bom_id": bom.id,
                 "product_id": bom_product.id,
-                "product_qty": 1,
+                "product_qty": 3,
                 "product_uom_id": self.env.ref("uom.product_uom_unit").id,
             }
         )


### PR DESCRIPTION
just a fw-port of the fix in https://github.com/OCA/stock-logistics-availability/pull/32