### PR TITLE
[16.0][FIX] stock_available_unreserved: value not computed

### DIFF
--- a/stock_available_unreserved/models/product_template.py
+++ b/stock_available_unreserved/models/product_template.py
@@ -21,6 +21,7 @@ class ProductTemplate(models.Model):
     def _compute_product_available_not_res(self):
         for tmpl in self:
             if isinstance(tmpl.id, models.NewId):
+                tmpl.qty_available_not_res = 0.0
                 continue
             tmpl.qty_available_not_res = sum(
                 tmpl.mapped("product_variant_ids.qty_available_not_res")


### PR DESCRIPTION
When product template is related to another product template, modifying first one caused an error trying to compute second one's value for field `qty_available_not_res`.

Field should not remain without value, same approach was being followed in `stock.quant` of same module [here](https://github.com/OCA/stock-logistics-availability/blob/5597c21f33223f593f4261227c5c5b8230a7116f/stock_available_unreserved/models/stock_quant.py#L21-L22)