### PR TITLE
[16.0][FIX] stock_available_immediately_exclude_location:  Fixed available update quantity

### DIFF
--- a/stock_available_immediately_exclude_location/models/stock_location.py
+++ b/stock_available_immediately_exclude_location/models/stock_location.py
@@ -23,7 +23,7 @@ class StockLocation(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if vals.get("exclude_from_immediately_usable_qty"):
+        if "exclude_from_immediately_usable_qty" in vals:
             self._invalidate_location_ids_excluded_from_immediatley_usable_qty_cache()
         return res
 


### PR DESCRIPTION
Fixed the available quantity calculation when updating the 'exclude_from_immediately_usable_qty' field.
Previously, the cache invalidation only occurred when the field was set to True.
It triggers correctly regardless of the boolean value change (True or False).

Steps to reproduce:
1. Set `exclude_from_immediately_usable_qty = True` on a location and observe `Available` updates at the product level.
2. Then set it back to `False`.
3. Notice that the `Available` quantity at the product level did not update correctly because the cache was not cleared.

This fix ensures the cache is always invalidated when the field changes, maintaining correct available quantity behaviour.