### PR TITLE
[18.0][FW][FIX] stock_available_unreserved: value not computed

### DIFF
--- a/stock_available_unreserved/models/product_template.py
+++ b/stock_available_unreserved/models/product_template.py
@@ -21,6 +21,7 @@ class ProductTemplate(models.Model):
     def _compute_product_available_not_res(self):
         for tmpl in self:
             if isinstance(tmpl.id, models.NewId):
+                tmpl.qty_available_not_res = 0.0
                 continue
             tmpl.qty_available_not_res = sum(
                 tmpl.mapped("product_variant_ids.qty_available_not_res")


### PR DESCRIPTION
When product template is related to another product template, modifying first one caused an error trying to compute second one's value for field `qty_available_not_res`.

Forward port of https://github.com/OCA/stock-logistics-availability/pull/57