### PR TITLE
[18.0][FIX]stock_free_quantity: Fix the free quantity calculation for products with variants

### DIFF
--- a/stock_free_quantity/models/product_template.py
+++ b/stock_free_quantity/models/product_template.py
@@ -8,7 +8,7 @@ class ProductTemplate(models.Model):
         prod_available = super()._compute_quantities_dict()
         for template in self:
             free_qty = 0
-            for p in template.with_context(active_test=False).product_variant_ids:
+            for p in template.product_variant_ids:
                 free_qty += p.free_qty
             prod_available[template.id]["free_qty"] = free_qty
         return prod_available


### PR DESCRIPTION

The free qty calculation, when a product has not active variants, is taking the free qty of this variants to make the free qty calculation of the product

Before:
<img width="415" height="188" alt="image" src="https://github.com/user-attachments/assets/00b94a17-6c84-4693-b2ba-516f1eba271c" />

After:
<img width="369" height="147" alt="image" src="https://github.com/user-attachments/assets/011512f4-a12e-4016-a10f-c2447f9eaf61" />
