### PR TITLE
[16.0] [FIX] stock_available_immediately: kit immediately_usable_qty computed from components

### DIFF
--- a/stock_available_immediately/__manifest__.py
+++ b/stock_available_immediately/__manifest__.py
@@ -11,6 +11,9 @@
     "website": "https://github.com/OCA/stock-logistics-availability",
     "author": "Camptocamp,Sodexis,Odoo Community Association (OCA),Sergio Díaz",
     "license": "AGPL-3",
+    "data": [
+        "views/res_config_settings_views.xml",
+    ],
     "category": "Hidden",
     "installable": True,
 }

--- a/stock_available_immediately/i18n/es.po
+++ b/stock_available_immediately/i18n/es.po
@@ -1,28 +1,39 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * stock_available_immediately
+# 	* stock_available_immediately
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-01-16 14:35+0000\n"
-"PO-Revision-Date: 2023-02-01 10:46+0000\n"
-"Last-Translator: FranciscoFactorLibre <francisco.santos@factorlibre.com>\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"POT-Creation-Date: 2025-07-23 13:44+0000\n"
+"PO-Revision-Date: 2025-07-23 15:45+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. module: stock_available_immediately
+#: model:ir.model,name:stock_available_immediately.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ajustes de configuración"
+
+#. module: stock_available_immediately
+#: model:ir.model.fields,field_description:stock_available_immediately.field_res_config_settings__compute_stock_available_immediately
+msgid "Exclude incoming goods"
+msgstr "Excluir mercancías entrantes"
 
 #. module: stock_available_immediately
 #: model:ir.model,name:stock_available_immediately.model_product_product
 msgid "Product Variant"
-msgstr "Variantes de producto"
+msgstr "Variante de producto"
 
-#~ msgid "Product"
-#~ msgstr "Producto"
+#. module: stock_available_immediately
+#: model:ir.model.fields,help:stock_available_immediately.field_res_config_settings__compute_stock_available_immediately
+msgid ""
+"This will subtract incoming quantities from the quantities available to promise."
+msgstr "Esto restará las cantidades entrantes de las cantidades disponibles para prometer."

--- a/stock_available_immediately/i18n/stock_available_immediately.pot
+++ b/stock_available_immediately/i18n/stock_available_immediately.pot
@@ -2,18 +2,39 @@
 # This file contains the translation of the following modules:
 # 	* stock_available_immediately
 #
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-24 12:12+0200\n"
+"PO-Revision-Date: 2025-07-24 10:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. module: stock_available_immediately
+#: model:ir.model,name:stock_available_immediately.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: stock_available_immediately
+#: model:ir.model.fields,field_description:stock_available_immediately.field_res_config_settings__compute_stock_available_immediately
+msgid "Exclude incoming goods"
+msgstr ""
 
 #. module: stock_available_immediately
 #: model:ir.model,name:stock_available_immediately.model_product_product
 msgid "Product Variant"
+msgstr ""
+
+#. module: stock_available_immediately
+#: model:ir.model.fields,help:stock_available_immediately.field_res_config_settings__compute_stock_available_immediately
+msgid ""
+"This will subtract incoming quantities from the quantities available to "
+"promise."
 msgstr ""

--- a/stock_available_immediately/models/__init__.py
+++ b/stock_available_immediately/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_product
+from . import res_config_settings

--- a/stock_available_immediately/models/product_product.py
+++ b/stock_available_immediately/models/product_product.py
@@ -11,10 +11,20 @@ class ProductProduct(models.Model):
 
     def _compute_available_quantities_dict(self):
         res, stock_dict = super()._compute_available_quantities_dict()
-        for product in self:
-            res[product.id]["immediately_usable_qty"] -= stock_dict[product.id][
-                "incoming_qty"
-            ]
+        param = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(
+                "stock_available_immediately.compute_stock_available_immediately",
+                "True",
+            )
+        )
+
+        if param == "True":
+            for product in self:
+                res[product.id]["immediately_usable_qty"] -= stock_dict[product.id][
+                    "incoming_qty"
+                ]
         return res, stock_dict
 
     @api.depends("virtual_available", "incoming_qty")

--- a/stock_available_immediately/models/res_config_settings.py
+++ b/stock_available_immediately/models/res_config_settings.py
@@ -1,0 +1,30 @@
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    compute_stock_available_immediately = fields.Boolean(
+        string="Exclude incoming goods",
+        help="This will subtract incoming quantities from the quantities "
+        "available to promise.",
+    )
+
+    @api.model
+    def get_values(self):
+        res = super().get_values()
+        param_env = self.env["ir.config_parameter"].sudo()
+        value = param_env.get_param(
+            "stock_available_immediately.compute_stock_available_immediately", "True"
+        )
+        res.update(compute_stock_available_immediately=value == "True")
+        return res
+
+    def set_values(self):
+        res = super().set_values()
+        ir_config_sudo = self.env["ir.config_parameter"].sudo()
+        ir_config_sudo.set_param(
+            "stock_available_immediately.compute_stock_available_immediately",
+            str(self.compute_stock_available_immediately),
+        )
+        return res

--- a/stock_available_immediately/views/res_config_settings_views.xml
+++ b/stock_available_immediately/views/res_config_settings_views.xml
@@ -1,0 +1,27 @@
+<odoo>
+    <record id="view_stock_configuration" model="ir.ui.view">
+        <field name="name">Stock settings: quantity available to promise</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='module_stock_available_immediately']"
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='module_stock_available_immediately']"
+                position="after"
+            >
+                <field name="compute_stock_available_immediately" />
+            </xpath>
+            <xpath
+                expr="//label[@for='module_stock_available_immediately']"
+                position="after"
+            >
+                <label for="compute_stock_available_immediately" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
For products with a phantom BoM (kits), the formula
`immediately_usable_qty = virtual_available - incoming_qty` applied to the
aggregated kit fields produces inconsistent results because each aggregated
kit field (`virtual_available`, `incoming_qty`, ...) is computed by Odoo MRP
as an independent `min` over the components and may be limited by different
components. Subtracting two such mins is not equivalent to
`qty_available - outgoing_qty` for kits, even though that algebraic
cancellation does hold for plain products.

### Example

Kit with two components, `need=2` each:

```
Component A: qty=8,    in=133, out=14   →  virtual=127,  immediately=-6
Component B: qty=4258, in=60,  out=168  →  virtual=4150, immediately=4090

Forecasted (kit) = min(127/2, 4150/2)  = 63    ← limited by A
Incoming   (kit) = min(133/2, 60/2)    = 30    ← limited by B
immediately_usable_qty (current bug) = 63 - 30 = 33   ← inflated, not physical
immediately_usable_qty (expected)    = min(-6/2, 4090/2) = -3
```

### Fix

When the `mrp` module is installed, recompute `immediately_usable_qty` for
products with a phantom BoM directly from the components (whose individual
values do hold the correct cancellation) and aggregate them with
`min(component / qty_per_kit)`. The other kit fields (`qty_available`,
`virtual_available`, `incoming_qty`, `outgoing_qty`, `free_qty`) are
intentionally left untouched and keep the standard Odoo MRP aggregation.

If `mrp` is not installed, behaviour is unchanged.

### Tests

Added covering:

- Unbalanced components reproducing the bug → expected negative result.
- Balanced components → no change vs. previous behaviour.
- All-positive components → standard healthy case.
- Oversold components → propagation to the kit value.
- Plain products without BoM → not affected (regression).
- Consumable components → skipped in the ratio, only storable components limit.
