### PR TITLE
[19.0][FIX] stock_available: fix the context keys the quantities depend on

### DIFF
--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -57,7 +57,8 @@ class ProductProduct(models.Model):
         "from_date",
         "to_date",
         "location",
-        "warehouse",
+        "warehouse_id",
+        "allowed_company_ids",
     )
     def _compute_available_quantities(self):
         res, _ = self._compute_available_quantities_dict()


### PR DESCRIPTION
Since 19.0, `stock` only filters the quantities by the `warehouse_id` context key: `warehouse` isn't read anymore (https://github.com/odoo/odoo/blob/b0907482898d097054a432974a68eb1ecee65326/addons/stock/models/product.py#L370). As it was the key declared in `depends_context`, the ORM cache key of `immediately_usable_qty` didn't take the warehouse into account, so once the field was computed for one warehouse, every other warehouse got that very same value.

`allowed_company_ids` was missing as well, although `virtual_available`, which this field is computed from, does depend on it.

cc @Tecnativa

ping @sergio-teruel @Andrii9090-tecnativa 