### PR TITLE
[18.0][FIX] stock_available: fix the context keys the quantities depend on

### DIFF
--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -57,7 +57,8 @@ class ProductProduct(models.Model):
         "from_date",
         "to_date",
         "location",
-        "warehouse",
+        "warehouse_id",
+        "allowed_company_ids",
     )
     def _compute_available_quantities(self):
         res, _ = self._compute_available_quantities_dict()


### PR DESCRIPTION
Backport of #82, which was merged into 19.0. 18.0 is affected identically: `stock` reads only the `warehouse_id` context key there too (`_get_domain_locations`, `addons/stock/models/product.py`, no fallback to `warehouse`), so the ORM cache key of `immediately_usable_qty` does not take the warehouse into account and every warehouse gets the value computed for the first one.

Measured on an 18.0 database with two warehouses whose real quantities are 200 and 89: `immediately_usable_qty` returned 200 for both until this change; `qty_available`, which declares the right key, returned 200 and 89.

Cherry-picked from 9d5e7ce, authorship preserved. cc @Tecnativa @sergio-teruel